### PR TITLE
ci: add CI, release, and security workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+# .github/labeler.yml — path-based PR auto-labels (actions/labeler@v5 format).
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ["**/*.md", "docs/**"]
+ci:
+  - changed-files:
+      - any-glob-to-any-file: [".github/**"]
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          ["**/package.json", "**/pubspec.yaml", "**/go.mod", "**/*.lock", "**/*lock.yaml"]
+tests:
+  - changed-files:
+      - any-glob-to-any-file: ["**/*.test.*", "**/*_test.*", "test/**", "**/__tests__/**"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - name: Analyze
+        run: flutter analyze
+      - name: Test
+        run: |
+          if [ -d test ] && grep -rqlE 'test\(|testWidgets\(' test; then
+            flutter test
+          else
+            echo "no test cases found — skipping"
+          fi

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+name: Dependency Review
+
+# Flags vulnerable or disallowed-license dependencies introduced by a PR before
+# they merge. Replaces Dependabot's alerting with a hard PR gate.
+on:
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+# Auto-labels PRs by the paths they touch (config in .github/labeler.yml).
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+# On push to the default branch (a merged PR), tag v<pubspec version> and create
+# a GitHub Release with generated notes — unless the tag already exists. (Apps
+# are not published to pub.dev, so no publish step.)
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Tag and release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Read version
+        id: v
+        run: |
+          version=$(grep -E '^version:' pubspec.yaml | head -1 | awk '{print $2}' | tr -d '\r')
+          # pubspec app versions are often "x.y.z+build"; tag on the semver part.
+          echo "tag=v${version%%+*}" >> "$GITHUB_OUTPUT"
+      - name: Release if new
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.v.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1 \
+            || git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "Tag $TAG already exists — skipping."; exit 0
+          fi
+          gh release create "$TAG" --target "${{ github.sha }}" --title "$TAG" --generate-notes
+          echo "Released $TAG ✓"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,32 @@
+name: Scorecard
+
+# OpenSSF Scorecard — supply-chain security posture. Runs on push to the default
+# branch and weekly; uploads SARIF so findings show in the Security tab.
+on:
+  push:
+    branches: ["master"]
+  schedule:
+    - cron: "27 3 * * 1" # Mondays 03:27 UTC
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      id-token: write # publish results to the OpenSSF API
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Stale
+
+# Marks inactive issues/PRs stale, then closes them after a grace period.
+on:
+  schedule:
+    - cron: "0 4 * * *" # daily 04:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security,blocked
+          exempt-pr-labels: pinned,security,blocked
+          stale-issue-message: >
+            This issue has been inactive for 60 days and is now marked stale.
+            Comment to keep it open; it will close in 14 days otherwise.
+          stale-pr-message: >
+            This PR has been inactive for 60 days and is now marked stale.
+            Push or comment to keep it open; it will close in 14 days otherwise.

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,47 @@
+name: Version Check
+
+# Every PR must bump the pubspec.yaml version. Release tags it on merge; the
+# existing publish workflow then publishes to pub.dev on that tag.
+on:
+  pull_request:
+    branches: ["master"]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  version-bumped:
+    name: version bumped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need the base branch to diff the version
+          persist-credentials: false
+      - name: Read versions
+        id: v
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          read_ver() { grep -E '^version:' "$1" | head -1 | awk '{print $2}' | tr -d '\r'; }
+          pr=$(read_ver pubspec.yaml)
+          git show "origin/${{ github.base_ref }}:pubspec.yaml" > /tmp/base_pubspec.yaml
+          base=$(read_ver /tmp/base_pubspec.yaml)
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+      - name: Compare
+        env:
+          PR: ${{ steps.v.outputs.pr }}
+          BASE: ${{ steps.v.outputs.base }}
+        run: |
+          echo "base=$BASE  pr=$PR"
+          if [ "$PR" = "$BASE" ]; then
+            echo "::error::pubspec.yaml version not bumped (still $BASE)."
+            exit 1
+          fi
+          greater=$(printf '%s\n%s\n' "$BASE" "$PR" | sort -V | tail -n1)
+          if [ "$greater" != "$PR" ]; then
+            echo "::error::pubspec.yaml version $PR is lower than base $BASE."
+            exit 1
+          fi
+          echo "Version bumped $BASE -> $PR ✓"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A social media app using Flutter, Dart, GetX, and REST API that all
 
 publish_to: "none"
 
-version: 1.0.1+31
+version: 1.0.2+32
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Adds standardized GitHub Actions workflows to this Flutter app (no existing CI).

## Workflows
- **ci.yml** — `flutter analyze` + guarded `flutter test` (skips when no tests exist) on push/PR to `master`.
- **version-check.yml** — fails any PR that doesn't bump `pubspec.yaml` `version:`.
- **release.yml** — on merge to `master`, tags `v<semver>` (the part before `+`) and creates a GitHub Release with generated notes. No pub.dev publish since this is an app, not a package.
- **dependency-review.yml** — blocks high-severity / disallowed-license deps on PRs.
- **scorecard.yml** — OpenSSF Scorecard supply-chain posture (push + weekly).
- **stale.yml** — marks/closes inactive issues & PRs.
- **labeler.yml** + **.github/labeler.yml** — path-based PR auto-labels.

## Other
- Bumped `pubspec.yaml` version `1.0.1+31` -> `1.0.2+32` to satisfy version-check.

All workflows pass `actionlint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **1.0.2+32**.
  * Added automated checks for version updates, dependency review, and security scoring.
  * Introduced faster CI handling with automatic cancellation of outdated runs.
  * Added automatic PR labels based on changed files.

* **Bug Fixes**
  * Improved release safeguards to prevent duplicate releases and ensure version numbers move forward.
  * Added stale-item management to help keep issues and pull requests organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---
## ⚠️ CI `build` job status: failing on pre-existing source issues

The `flutter analyze` step (working as intended) surfaces **243 issues**, including hard compile errors that exist in the repo today — they are **not** caused by these workflows:

- `package:rive/rive.dart` import unresolved (the `rive` dependency is commented out in `pubspec.yaml:33`); `RiveAnimation` undefined in `server_maintenance_view.dart` and `server_offline_view.dart`.
- `package:social_media_app/constants/secrets.dart` missing / `AppSecrets` undefined in `verification_controller.dart` (the secrets file is gitignored and not committed).
- `XFile?` assigned to `File?` in `lib/utils/file_utility.dart:67`.
- Undefined named parameter `backgroudColor` (typo) in `help_settings_view.dart:178`.
- ~230 lint infos (directive ordering, deprecated `withOpacity`/`WillPopScope`, etc.).

Per scope, **no source was modified** and the analyze step was **not** weakened. The other jobs (version-check, dependency-review) pass. The `build` job will go green once the repo's existing analyze issues are addressed separately.